### PR TITLE
Try publishing to cision's npm to get around yarn / git package management bug

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=http://registry.npmjs.org/
-@pixelbandito:registry=https://npm.pkg.github.com/pixelbandito

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 
 **True modularity in styling responsive component.**
 
-[![npm version](https://badge.fury.io/js/react-container-query.svg)](https://badge.fury.io/js/react-container-query)
-[![Circle CI](https://circleci.com/gh/d6u/react-container-query/tree/master.svg?style=svg)](https://circleci.com/gh/d6u/react-container-query/tree/master)
-[![Build Status](https://saucelabs.com/buildstatus/react-cq)](https://saucelabs.com/beta/builds/de7d8039f4e5417399ec27c39036c1b8)
-[![codecov](https://codecov.io/gh/d6u/react-container-query/branch/master/graph/badge.svg)](https://codecov.io/gh/d6u/react-container-query)
-
-[![Build Status](https://saucelabs.com/browser-matrix/react-cq.svg)](https://saucelabs.com/beta/builds/de7d8039f4e5417399ec27c39036c1b8)
+[![NPM](https://img.shields.io/npm/v/@cision/react-container-query.svg)](https://www.npmjs.com/package/@cision/react-container-query)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@pixelbandito/react-container-query",
-  "version": "1.0.0-alpha.2",
+  "name": "@cision/react-container-query",
+  "version": "1.0.0-alpha.3",
   "description": "Container Query for React Component",
   "author": "Daiwei Lu <daiweilu123@gmail.com> (http://daiwei.lu) (Forked by Chris Garcia <pixelbandito@gmail.com>)",
   "repository": {
@@ -17,9 +17,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/d6u/react-container-query/issues"
+    "url": "https://github.com/pixelbandito/react-container-query/issues"
   },
-  "homepage": "https://github.com/d6u/react-container-query",
+  "homepage": "https://github.com/pixelbandito/react-container-query",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
@@ -91,8 +91,5 @@
     "combine-coverage-results": "istanbul-combine -d coverage/summary -p both -r json -r html coverage/*-json/coverage-final.json",
     "ci": "npm test && npm run combine-coverage-results",
     "preversion": "npm run clean && npm run build"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
I'd prefer to get some updates into the upstream d6u/react-container-query project, but this package should at least solve the problem for our org.

The previous version (alpha 2) published to GitHub's npm registry, but there were errors using GitHub's registry with yarn.